### PR TITLE
添加黑名单机制

### DIFF
--- a/Api/SunnyNet.go
+++ b/Api/SunnyNet.go
@@ -1457,6 +1457,58 @@ func ProcessCancelAll(SunnyContext int) {
 	}
 }
 
+
+// ProcessDelBlackName 进程代理 删除黑名单进程名
+func ProcessDelBlackName(SunnyContext int, s string) {
+	SunnyNet.SunnyStorageLock.Lock()
+	w := SunnyNet.SunnyStorage[SunnyContext]
+	SunnyNet.SunnyStorageLock.Unlock()
+	if w != nil {
+		w.ProcessDelBlackName(s)
+	}
+}
+
+// ProcessAddBlackName 进程代理 添加黑名单进程名
+func ProcessAddBlackName(SunnyContext int, s string) {
+	SunnyNet.SunnyStorageLock.Lock()
+	w := SunnyNet.SunnyStorage[SunnyContext]
+	SunnyNet.SunnyStorageLock.Unlock()
+	if w != nil {
+		w.ProcessAddBlackName(s)
+	}
+}
+
+// ProcessDelBlackPid 进程代理 删除黑名单PID
+func ProcessDelBlackPid(SunnyContext, pid int) {
+	SunnyNet.SunnyStorageLock.Lock()
+	w := SunnyNet.SunnyStorage[SunnyContext]
+	SunnyNet.SunnyStorageLock.Unlock()
+	if w != nil {
+		w.ProcessDelBlackPid(pid)
+	}
+}
+
+// ProcessAddBlackPid 进程代理 添加黑名单PID
+func ProcessAddBlackPid(SunnyContext, pid int) {
+	SunnyNet.SunnyStorageLock.Lock()
+	w := SunnyNet.SunnyStorage[SunnyContext]
+	SunnyNet.SunnyStorageLock.Unlock()
+	if w != nil {
+		w.ProcessAddBlackPid(pid)
+	}
+}
+
+// ProcessCancelBlackAll 进程代理 取消全部已设置的黑名单进程名
+func ProcessCancelBlackAll(SunnyContext int) {
+	SunnyNet.SunnyStorageLock.Lock()
+	w := SunnyNet.SunnyStorage[SunnyContext]
+	SunnyNet.SunnyStorageLock.Unlock()
+	if w != nil {
+		w.ProcessCancelBlackAll()
+	}
+}
+
+
 // SetScriptCode 加载用户的脚本代码
 func SetScriptCode(SunnyContext int, code string) string {
 	SunnyNet.SunnyStorageLock.Lock()

--- a/README_api.md
+++ b/README_api.md
@@ -72,6 +72,11 @@
 - `ProcessAddPid(SunnyContext, pid int)` - 进程代理添加PID
 - `ProcessDelPid(SunnyContext, pid int)` - 进程代理删除PID
 - `ProcessCancelAll(SunnyContext int)` - 进程代理取消全部已设置的进程名
+- `ProcessAddBlackName(SunnyContext int, Name *C.char)` - 进程代理添加进程名
+- `ProcessDelBlackName(SunnyContext int, Name *C.char)` - 进程代理删除进程名
+- `ProcessAddBlackPid(SunnyContext, pid int)` - 进程代理添加PID
+- `ProcessDelBlackPid(SunnyContext, pid int)` - 进程代理删除PID
+- `ProcessCancelBlackAll(SunnyContext int)` - 进程代理取消全部已设置的进程名
 - `ProcessALLName(SunnyContext int, open, StopNetwork bool)` - 进程代理设置是否全部进程通过
 
 ### 网络设置

--- a/SunnyNet/SunnyNet.go
+++ b/SunnyNet/SunnyNet.go
@@ -2296,6 +2296,41 @@ func (s *Sunny) ProcessCancelAll() *Sunny {
 	return s
 }
 
+// ProcessDelBlackName 删除黑名单进程名  所有 SunnyNet 通用
+func (s *Sunny) ProcessDelBlackName(name string) *Sunny {
+	ProcessCheck.DelBlackName(name)
+	//CrossCompiled.NFapi_CloseNameTCP(name)
+	return s
+}
+
+// ProcessAddBlackName 进程代理 添加黑名单进程名，添加黑名单后SunnyNet将不会为它代理，即使开启了代理全部进程 所有 SunnyNet 通用
+func (s *Sunny) ProcessAddBlackName(Name string) *Sunny {
+	ProcessCheck.AddBlackName(Name)
+	//CrossCompiled.NFapi_CloseNameTCP(Name)
+	return s
+}
+
+// ProcessDelPid 删除BlackPID  所有 SunnyNet 通用
+func (s *Sunny) ProcessDelBlackPid(Pid int) *Sunny {
+	ProcessCheck.DelBlackPid(uint32(Pid))
+	//CrossCompiled.NFapi_ClosePidTCP(Pid)
+	return s
+}
+
+// ProcessAddBlackPid 进程代理 添加BlackPID 所有 SunnyNet 通用
+func (s *Sunny) ProcessAddBlackPid(Pid int) *Sunny {
+	ProcessCheck.AddBlackPid(uint32(Pid))
+	//CrossCompiled.NFapi_ClosePidTCP(Pid)
+	return s
+}
+
+// ProcessCancelBlackAll 进程代理 取消全部已设置的黑名单进程名
+func (s *Sunny) ProcessCancelBlackAll() *Sunny {
+	ProcessCheck.CancelBlackAll()
+	//CrossCompiled.NFapi_ClosePidTCP(-1)
+	return s
+}
+
 // SetScriptCall 设置脚本代码的回调函数
 func (s *Sunny) SetScriptCall(log GoScriptCode.LogFuncInterface, save GoScriptCode.SaveFuncInterface) {
 	s.lock.Lock()

--- a/src/ProcessDrv/ProcessCheck/main.go
+++ b/src/ProcessDrv/ProcessCheck/main.go
@@ -160,6 +160,49 @@ func CancelAll() bool {
 	return true
 }
 
+func AddBlackName(u string) bool {
+	Lock.Lock()
+	BlackName[strings.ToLower(u)] = true
+	Lock.Unlock()
+	CloseNameTCP(u)
+	return true
+}
+func DelBlackName(u string) bool {
+	Lock.Lock()
+	delete(BlackName, strings.ToLower(u))
+	Lock.Unlock()
+	CloseNameTCP(u)
+	return true
+}
+func AddBlackPid(u uint32) bool {
+	Lock.Lock()
+	BlackPid[u] = true
+	Lock.Unlock()
+	ClosePidTCP(int(u))
+	return true
+}
+func DelBlackPid(u uint32) bool {
+	Lock.Lock()
+	delete(BlackPid, u)
+	Lock.Unlock()
+	ClosePidTCP(int(u))
+	return true
+}
+func CancelBlackAll() bool {
+	Lock.Lock()
+	for u := range BlackName {
+		CloseNameTCP(u)
+		delete(BlackName, u)
+	}
+	for u := range BlackPid {
+		ClosePidTCP(int(u))
+		delete(BlackPid, u)
+	}
+	Lock.Unlock()
+	return true
+}
+
+
 func AddDevObj(connPort uint16, info DrvInfo) {
 	Lock.Lock()
 	Proxy[connPort] = info
@@ -175,6 +218,15 @@ func DelDevObj(connPort uint16) {
 func CheckPidByName(pid int32, name string) bool {
 	Lock.Lock()
 	defer Lock.Unlock()
+	if BlackName[strings.ToLower(name)] == false {
+		if BlackPid[uint32(pid)] == false {
+			return false
+		}else{
+			return true
+		}
+	}else{
+		return true
+	}
 	if HookProcess {
 		return false
 	}


### PR DESCRIPTION
解决问题：使用ProcessALLName时，会代理所有进程；如果有了黑名单，就可以将黑名单中的进程排除（因为python的requests库如果verify=True，sunnyNet是代理它是会引发SSL：CERTIFICATE_VERIFY_FAILED错误的）。
我只在windows 11 26100下测试了并表现为成功。